### PR TITLE
merge dev -> v1.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: 5.8.0
     hooks:
       - id: isort
+        args: ["--profile=black"]
   - repo: https://github.com/ambv/black
     rev: 21.4b2
     hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,16 @@
 Changelog
 =========
 
+v1.0.0
+------
+- now has a full test suite! 🎉
+- can now initialize a :code:`NextGenPump` instance using either a pre-existing :code:`Serial` instance (new behavior), OR by passing in a string for the port to open a :code:`Serial` instance at (old behavior)
+- bundled data retrieval methods such as :code:`current_conditions` or :code:`pump_info` now return custom typed :code:`dataclass`es instead of :code:`dict`s (this is a breaking change)
+- fixed an elusive bug that would sometimes cause :code:`NextGenPumpBase`'s :code:`identify` to fail
+
 v0.1.7
 ------
- - minor code cleanup / improvement to packaging
+- minor code cleanup / improvement to packaging
 
 v0.1.6
 ------

--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,11 @@ The interface behaves in a typical way. Pumps can be inspected or configured wit
   >>> pump.flowrate
   5.5
   >>> pump.run()
+  'OK/'
   >>> pump.is_running
   True
   >>> pump.stop()
+  'OK/'
   >>> pump.is_running
   False
   >>> pump.leak_detected

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ An unoffical Python wrapper for the SSI-Teledyne Next Generation class HPLC pump
 MIT license, (C) 2021 Alex Whittington <alex@southsun.tech>
 
 This project is stable and usable in a production environment, but listed as in beta due to the lack of a test suite (yet!).
-If you notice something weird, fragile, or otherwise encounter a bug, please open an `issue`_. 
+If you notice something weird, fragile, or otherwise encounter a bug, please open an `issue`_.
 
 Installation
 =============
@@ -30,43 +30,50 @@ Using the package
 
 You can open a pump instance like this ::
 
-   >>> from py_hplc import NextGenPump
-   >>> pump = NextGenPump("COM3")  # or "/dev/ttyUSB0", etc.
+  >>> from py_hplc import NextGenPump
+  >>> pump = NextGenPump("COM3")  # or "/dev/ttyUSB0", etc.
+
+Or like this ::
+
+  >>> from py_hplc import NextGenPump
+  >>> from serial import Serial
+  >>> device = Serial("COM3")  # or "/dev/ttyUSB0", etc.
+  >>> pump = NextGenPump(device)
 
 You can inspect the pump for useful information such as its pressure units, firmware version, max flowrate, etc. ::
 
-   >>> pump.version
-   '191017 Version 2.0.8'
-   >>> pump.pressure_units
-   'psi'
-   >>> pump.pressure
-   100
+  >>> pump.version
+  '191017 Version 2.0.8'
+  >>> pump.pressure_units
+  'psi'
+  >>> pump.pressure
+  100
 
 The interface behaves in a typical way. Pumps can be inspected or configured without the use of getters and setters. ::
 
-    >>> pump.flowrate
-    10.0
-    >>> pump.flowrate = 5.5  # mL / min
-    >>> pump.flowrate
-    5.5
-    >>> pump.run()
-    >>> pump.is_running
-    True
-    >>> pump.stop()
-    >>> pump.is_running
-    False
-    >>> pump.leak_detected
-    False
+  >>> pump.flowrate
+  10.0
+  >>> pump.flowrate = 5.5  # mL / min
+  >>> pump.flowrate
+  5.5
+  >>> pump.run()
+  >>> pump.is_running
+  True
+  >>> pump.stop()
+  >>> pump.is_running
+  False
+  >>> pump.leak_detected
+  False
 
 | Some pump commands, such as "CC" (current conditions), return many pieces of data at once.
-| This package makes the data available in concise, descriptive, value-typed dictionaries.
+| This package makes the data available in concise, descriptive, value-typed dataclasses.
 
 ::
 
-   >>> pump.current_conditions()
-   {'response': 'OK,0000,10.00/', 'pressure': 0, 'flowrate': 10.0}
-   >>> pump.read_faults()
-   {'response': 'OK,0,0,0/', 'motor stall fault': False, 'upper pressure fault': False, 'lower pressure fault': False}
+  >>> pump.current_conditions()
+  CurrentConditions(pressure=0, flowrate=10.0, response='OK,0000,10.00/')
+  >>> pump.read_faults()
+  Faults(motor_stall_fault=False, upper_pressure_fault=False, lower_pressure_fault=False, response='OK,0,0,0/')
 
 See the `API Documentation`_ for more usage examples.
 

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -1,0 +1,22 @@
+How to test the interface
+=========================
+
+Basic functionality can be tested for using Python's :code:`unittest` module.
+
+- :code:`test_pump_base.py` contains tests for interacting with the serial connection
+- :code:`test_pump.py` contains tests for the higher-level command wrappers 
+
+The tests can be run as follows ::
+
+    python -m unittest <PATH_TO_TEST> <PORT> 
+
+- <PATH_TO_TEST> is the path to the test you want to run
+- <PORT> is the local pump's serial port (eg. "COM3" or "/dev/ttyUSB0", etc.)
+
+.. note::
+
+    :code:`test_pump` will briefly run the pump, so make sure it is primed and connected to a solvent reservior.
+
+.. note::
+
+    Tests for :code:`NextGenPump`'s :code:`reset`, :code:`zero_seal`, and :code:`set_leak_mode` irreversibly modify the pump's configuration, and are disabled by default.

--- a/docs/pump.rst
+++ b/docs/pump.rst
@@ -1,5 +1,23 @@
 NextGenPump
 ================
 
-.. autoclass:: py_hplc.next_gen_pump.NextGenPump
+.. autoclass:: py_hplc.pump.NextGenPump
+    :members:
+
+.. autoclass:: py_hplc.pump.CurrentConditions
+    :members:
+
+.. autoclass:: py_hplc.pump.CurrentState
+    :members:
+
+.. autoclass:: py_hplc.pump.PumpInfo
+    :members:
+
+.. autoclass:: py_hplc.pump.Faults
+    :members:
+
+.. autoclass:: py_hplc.pump.Solvents
+    :members:
+
+.. autoclass:: py_hplc.pump.LeakModes
     :members:

--- a/docs/pump_base.rst
+++ b/docs/pump_base.rst
@@ -1,5 +1,5 @@
 NextGenPumpBase
 ================
 
-.. autoclass:: py_hplc.next_gen_pump_base.NextGenPumpBase
+.. autoclass:: py_hplc.pump_base.NextGenPumpBase
     :members:

--- a/docs/py_hplc.rst
+++ b/docs/py_hplc.rst
@@ -61,9 +61,11 @@ The interface behaves in a typical way. Pumps can be inspected or configured wit
     >>> pump.flowrate
     5.5
     >>> pump.run()
+    'OK/'
     >>> pump.is_running
     True
     >>> pump.stop()
+    'OK/'
     >>> pump.is_running
     False
     >>> pump.leak_detected

--- a/docs/py_hplc.rst
+++ b/docs/py_hplc.rst
@@ -37,6 +37,13 @@ You can open a pump instance like this ::
    >>> from py_hplc import NextGenPump
    >>> pump = NextGenPump("COM3")  # or "/dev/ttyUSB0", etc.
 
+Or like this ::
+
+  >>> from py_hplc import NextGenPump
+  >>> from serial import Serial
+  >>> device = Serial("COM3")  # or "/dev/ttyUSB0", etc.
+  >>> pump = NextGenPump(device)
+
 You can inspect the pump for useful information such as its pressure units, firmware version, max flowrate, etc. ::
 
    >>> pump.version
@@ -63,23 +70,23 @@ The interface behaves in a typical way. Pumps can be inspected or configured wit
     False
 
 | Some pump commands, such as "CC" (current conditions), return many pieces of data at once.
-| This package makes the data available in concise, descriptive, value-typed dictionaries.
+| This package makes the data available in concise, descriptive, value-typed dataclasses.
 
 ::
 
-   >>> pump.current_conditions()
-   {'response': 'OK,0000,10.00/', 'pressure': 0, 'flowrate': 10.0}
-   >>> pump.read_faults()
-   {'response': 'OK,0,0,0/', 'motor stall fault': False, 'upper pressure fault': False, 'lower pressure fault': False}
+  >>> pump.current_conditions()
+  CurrentConditions(pressure=0, flowrate=10.0, response='OK,0000,10.00/')
+  >>> pump.read_faults()
+  Faults(motor_stall_fault=False, upper_pressure_fault=False, lower_pressure_fault=False, response='OK,0,0,0/')
 
 .. note::
 
     | Some pump commands return values of 0 or 1 that have no meaning.
-    | These are omitted from the dictionaries, but may be inspected using the "response" key.
+    | These are omitted from the returned dataclasses, but may be inspected using the :code:`response` attribute.
 
     ::
 
-        >>> pump.pump_information()["response"]
+        >>> pump.pump_info().response
         'OK,10.00,0,0,S10S,0,1,0,0,0,0,0,0,0,0,0,0,0/'
 
 Advanced usage
@@ -115,11 +122,11 @@ Talking with the pumps directly
 
 A somewhat lower-level interface is provided on the pump object's :code:`command` and :code:`write` methods.
 These methods are defined in :code:`NextGenPumpBase` and all pump methods rely on these internally.
-:code:`command` will always return a response dictionary, or raise an exception if the pump responds with an error code.
-:code:`write` will only ever return the pump's decoded reponse as a string. ::
+:code:`command` will always return a response in the form of a string, or raise an exception if the pump responds with an error code.
+:code:`write` will only ever return the pump's decoded reponse as a string, regardless of if an error occurs. ::
 
    >>> pump.command("pr")
-   {'response': 'OK,0000/'}
+   'OK,0000/'
    >>> pump.write("QQ")
    'OK, Debug Commands Enabled/'
 

--- a/py_hplc/pump.py
+++ b/py_hplc/pump.py
@@ -15,7 +15,7 @@ from enum import Enum
 from logging import Logger
 from typing import TYPE_CHECKING
 
-from serial import Serial
+from serial.serialutil import SerialBase
 
 from py_hplc.pump_base import NextGenPumpBase
 
@@ -169,7 +169,7 @@ class NextGenPump(NextGenPumpBase):
     a string represtation of the pump's response.
     """
 
-    def __init__(self, device: Union[Serial, str], logger: Logger = None) -> None:
+    def __init__(self, device: Union[SerialBase, str], logger: Logger = None) -> None:
         """Inititalizes a `NextGenPump` instance.
 
         Args:

--- a/py_hplc/pump.py
+++ b/py_hplc/pump.py
@@ -169,7 +169,7 @@ class NextGenPump(NextGenPumpBase):
     a string represtation of the pump's response.
     """
 
-    def __init__(self, device: Union[str, Serial], logger: Logger = None) -> None:
+    def __init__(self, device: Union[Serial, str], logger: Logger = None) -> None:
         """Inititalizes a `NextGenPump` instance.
 
         Args:

--- a/py_hplc/pump_base.py
+++ b/py_hplc/pump_base.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 import logging
 from time import sleep
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
-from serial import SerialException, serial_for_url
+from serial import Serial, SerialException, serial_for_url
 from serial.serialutil import EIGHTBITS, PARITY_NONE, STOPBITS_ONE
 
 from py_hplc.pump_error import PumpError
@@ -22,23 +22,26 @@ if TYPE_CHECKING:
 class NextGenPumpBase:
     """Serial port wrapper for MX-class Teledyne pumps."""
 
-    def __init__(self, device: str, logger: Logger = None) -> None:
+    def __init__(self, device: Union[str, Serial], logger: Logger = None) -> None:
         # you'll have to reach in and add handlers yourself from the calling code
         if logger is None:  # append to the root logger
             self.logger = logging.getLogger(f"{logging.getLogger().name}.{device}")
         else:  # append to the passed logger
             self.logger = logging.getLogger(f"{logger.name}.{device}")
 
-        # fetch a platform-appropriate serial interface
-        self.serial = serial_for_url(
-            device,
-            baudrate=9600,
-            bytesize=EIGHTBITS,
-            do_not_open=True,
-            parity=PARITY_NONE,
-            stopbits=STOPBITS_ONE,
-            timeout=0.1,  # 100 ms
-        )
+        if isinstance(device, str):
+            # fetch a platform-appropriate serial interface
+            self.serial = serial_for_url(
+                device,
+                baudrate=9600,
+                bytesize=EIGHTBITS,
+                do_not_open=True,
+                parity=PARITY_NONE,
+                stopbits=STOPBITS_ONE,
+                timeout=0.1,  # 100 ms
+            )
+        elif isinstance(device, Serial):
+            self.serial = device
 
         # persistent identifying attributes
         self.max_flowrate: float = None

--- a/py_hplc/pump_base.py
+++ b/py_hplc/pump_base.py
@@ -10,8 +10,8 @@ import logging
 from time import sleep
 from typing import TYPE_CHECKING, Union
 
-from serial import Serial, SerialException, serial_for_url
-from serial.serialutil import EIGHTBITS, PARITY_NONE, STOPBITS_ONE
+from serial import SerialException, serial_for_url
+from serial.serialutil import EIGHTBITS, PARITY_NONE, STOPBITS_ONE, SerialBase
 
 from py_hplc.pump_error import PumpError
 
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 class NextGenPumpBase:
     """Serial port wrapper for MX-class Teledyne pumps."""
 
-    def __init__(self, device: Union[Serial, str], logger: Logger = None) -> None:
+    def __init__(self, device: Union[SerialBase, str], logger: Logger = None) -> None:
         # you'll have to reach in and add handlers yourself from the calling code
         if logger is None:  # append to the root logger
             self.logger = logging.getLogger(f"{logging.getLogger().name}.{device}")
@@ -40,7 +40,7 @@ class NextGenPumpBase:
                 stopbits=STOPBITS_ONE,
                 timeout=0.1,  # 100 ms
             )
-        elif isinstance(device, Serial):
+        elif isinstance(device, SerialBase):
             self.serial = device
 
         # persistent identifying attributes

--- a/py_hplc/pump_base.py
+++ b/py_hplc/pump_base.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 class NextGenPumpBase:
     """Serial port wrapper for MX-class Teledyne pumps."""
 
-    def __init__(self, device: Union[str, Serial], logger: Logger = None) -> None:
+    def __init__(self, device: Union[Serial, str], logger: Logger = None) -> None:
         # you'll have to reach in and add handlers yourself from the calling code
         if logger is None:  # append to the root logger
             self.logger = logging.getLogger(f"{logging.getLogger().name}.{device}")

--- a/py_hplc/pump_base.py
+++ b/py_hplc/pump_base.py
@@ -71,18 +71,16 @@ class NextGenPumpBase:
     def identify(self) -> None:
         """Gets persistent pump properties."""
         # general properties -----------------------------------------------------------
-        # firmware
-        response = self.command("id")
-        if "OK," in response:  # expect OK,<ID> Version <ver>/
-            self.version = response.split(",")[1][:-1].strip()
         # pump head
         response = self.command("pi")
         if "OK," in response:
             self.head = response.split(",")[4]
+
         # max flowrate
         response = self.command("mf")
         if "OK,MF:" in response:  # expect OK,MF:<max_flow>/
             self.max_flowrate = float(response.split(":")[1][:-1])
+
         # volumetric resolution - used for setting flowrates later
         # expect OK,<flow>,<UPL>,<LPL>,<p_units>,0,<R/S>,0/
         response = self.command("cs")
@@ -91,11 +89,18 @@ class NextGenPumpBase:
             self.flowrate_factor = -5  # FI takes microliters/min * 10 as ints
         else:  # eg. "5.000"
             self.flowrate_factor = -6  # FI takes microliters/min as ints
+
+        # version
+        response = self.command("id")
+        if "OK," in response:  # expect OK,<ID> Version <ver>/
+            self.version = response.split(",")[1][:-1].strip()
+
         # for pumps that have a pressure sensor ----------------------------------------
         # pressure units
         response = self.command("pu")
         if "OK," in response:  # expect "OK,<p_units>/"
             self.pressure_units = response.split(",")[1][:-1]
+
         # max pressure
         response = self.command("mp")
         if "OK,MP:" in response:  # expect "OK,MP:<max_pressure>/"

--- a/py_hplc/pump_base.py
+++ b/py_hplc/pump_base.py
@@ -54,7 +54,8 @@ class NextGenPumpBase:
         self.flowrate_factor: int = None  # used as 10 ** flowrate_factor
 
         # other configuration logic here
-        self.open()  # open the serial connection
+        if not self.is_open:
+            self.open()  # open the serial connection
         self.identify()  # populate attributes, takes about 0.16 s on avg
 
     def open(self) -> None:

--- a/py_hplc/pump_error.py
+++ b/py_hplc/pump_error.py
@@ -2,7 +2,7 @@
 
 
 class PumpError(Exception):
-    """Raised when the pump responds with the error code "Er/"."""
+    """Raised when the pump responds with the error code 'Er/'."""
 
     def __init__(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "py-hplc"
-version = "0.1.7"
+version = "1.0.0"
 description = "An unoffical Python wrapper for the SSI-Teledyne Next Generation class HPLC pumps."
 license = "MIT"
 repository = "https://github.com/teauxfu/py-hplc"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Modules for unit testing."""

--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -1,0 +1,158 @@
+"""This module tests the functionality of the NextGenPump class."""
+
+import sys
+import unittest
+from time import sleep
+
+from serial.serialutil import SerialException
+
+from py_hplc.pump import (
+    CurrentConditions,
+    CurrentState,
+    Faults,
+    NextGenPump,
+    PumpInfo,
+    Solvents,
+)
+from py_hplc.pump_error import PumpError
+
+
+class TestPump(unittest.TestCase):
+    SERIAL_PORT = "COM3"
+    PUMP = None
+
+    # setUp and tearDown will get run between each test method
+    def setUp(self) -> None:
+        try:
+            TestPump.PUMP = NextGenPump(self.SERIAL_PORT)
+        except SerialException:
+            self.fail(f"No such port {self.SERIAL_PORT}")
+
+    def tearDown(self) -> None:
+        self.PUMP.close()
+
+    def test_run_stop(self) -> None:
+        self.assertIn("OK", self.PUMP.run())
+        sleep(3)  # give the pump a moment to stroke
+        self.assertIn("OK", self.PUMP.stop())
+
+    def test_keypad_disable_enable(self) -> None:
+        self.assertIn("OK", self.PUMP.keypad_disable())
+        self.assertIn("OK", self.PUMP.keypad_enable())
+
+    def test_clear_faults(self) -> None:
+        self.assertIn("OK", self.PUMP.clear_faults())
+
+    def test_reset(self) -> None:
+        # resets pump to factory defaults -- this could be distruptive
+        # particularly if you care about your calibration / compensation values
+        # self.assertIn('OK', self.PUMP.reset())
+
+        pass
+
+    def test_zero_seal(self) -> None:
+        # this could be disruptive as the value cannot be set arbitrarily
+        # the stroke counter can only be retreived or set to 0
+        # self.assertIn('OK', self.PUMP.zero_seal())
+        pass
+
+    def test_current_conditions(self) -> None:
+        conditions = self.PUMP.current_conditions()
+        self.assertIsInstance(conditions, CurrentConditions)
+        self.assertIsInstance(conditions.pressure, (float, int))
+        self.assertIsInstance(conditions.flowrate, float)
+        self.assertIsInstance(conditions.response, str)
+
+    def test_current_state(self) -> None:
+        state = self.PUMP.current_state()
+        self.assertIsInstance(state, CurrentState)
+        self.assertIsInstance(state.flowrate, float)
+        self.assertIsInstance(state.upper_pressure_limit, (float, int))
+        self.assertIsInstance(state.lower_pressure_limit, (float, int))
+        self.assertIsInstance(state.pressure_units, str)
+        self.assertIsInstance(state.response, str)
+
+    def test_pump_information(self) -> None:
+        info = self.PUMP.pump_information()
+        self.assertIsInstance(info, PumpInfo)
+        self.assertIsInstance(info.flowrate, float)
+        self.assertIsInstance(info.is_running, bool)
+        self.assertIsInstance(info.pressure_compensation, float)
+        self.assertIsInstance(info.upper_pressure_fault, bool)
+        self.assertIsInstance(info.lower_pressure_fault, bool)
+        self.assertIsInstance(info.in_prime, bool)
+        self.assertIsInstance(info.keypad_enabled, bool)
+        self.assertIsInstance(info.motor_stall_fault, bool)
+        self.assertIsInstance(info.response, str)
+
+    def test_read_faults(self) -> None:
+        faults = self.PUMP.read_faults()
+        self.assertIsInstance(faults, Faults)
+        self.assertIsInstance(faults.motor_stall_fault, bool)
+        self.assertIsInstance(faults.upper_pressure_fault, bool)
+        self.assertIsInstance(faults.lower_pressure_fault, bool)
+        self.assertIsInstance(faults.response, str)
+
+    def test_is_running(self) -> None:
+        self.assertIsInstance(self.PUMP.is_running, bool)
+
+    def test_stroke_counter(self) -> None:
+        self.assertIsInstance(self.PUMP.stroke_counter, int)
+
+    def test_flowrate_compensation(self) -> None:
+        current = self.PUMP.flowrate_compensation
+        self.assertIsInstance(current, float)
+        self.PUMP.flowrate_compensation = current
+        self.assertEqual(current, self.PUMP.flowrate_compensation)
+
+    def test_flowrate(self) -> None:
+        current = self.PUMP.flowrate
+        self.assertIsInstance(current, float)
+        self.PUMP.flowrate = current
+        self.assertEqual(current, self.PUMP.flowrate)
+
+    def test_pressure(self) -> None:
+        self.assertIsInstance(self.PUMP.pressure, (float, int))
+
+    def test_upper_pressure_limit(self) -> None:
+        current = self.PUMP.upper_pressure_limit
+        self.assertIsInstance(current, (float, int))
+        self.PUMP.upper_pressure_limit = current
+        self.assertEqual(current, self.PUMP.upper_pressure_limit)
+
+    def test_lower_pressure_limit(self) -> None:
+        current = self.PUMP.lower_pressure_limit
+        self.assertIsInstance(current, (float, int))
+        self.PUMP.lower_pressure_limit = current
+        self.assertEqual(current, self.PUMP.lower_pressure_limit)
+
+    def test_leak_detected(self) -> None:
+        self.assertIsInstance(self.PUMP.leak_detected, bool)
+
+    def test_set_leak_mode(self) -> None:
+        # this value can only be set -- not retreived
+        # self.assertIn('OK', self.PUMP.set_leak_mode(1))
+        pass
+
+    def test_solvent(self) -> None:
+        # doesn't work with all models of pump
+        try:
+            self.PUMP.command("rs")
+        except PumpError:
+            return
+
+        current = self.PUMP.solvent
+        self.assertIsInstance(current, int)
+        # also test passing in a solvent name
+        self.PUMP.solvent = "water"
+        self.assertEqual(self.PUMP.solvent, Solvents.WATER)
+        self.PUMP.solvent = current
+        self.assertEqual(current, self.PUMP.solvent)
+
+
+if __name__ == "__main__":
+    # pass in the serial port you want to test on
+    # python -m unittest <FILE> <PORT>
+    if len(sys.argv) > 1:
+        TestPump.SERIAL_PORT = sys.argv.pop()
+    unittest.main()

--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -72,8 +72,8 @@ class TestPump(unittest.TestCase):
         self.assertIsInstance(state.pressure_units, str)
         self.assertIsInstance(state.response, str)
 
-    def test_pump_information(self) -> None:
-        info = self.PUMP.pump_information()
+    def test_pump_info(self) -> None:
+        info = self.PUMP.pump_info()
         self.assertIsInstance(info, PumpInfo)
         self.assertIsInstance(info.flowrate, float)
         self.assertIsInstance(info.is_running, bool)

--- a/tests/test_pump.py
+++ b/tests/test_pump.py
@@ -18,7 +18,7 @@ from py_hplc.pump_error import PumpError
 
 
 class TestPump(unittest.TestCase):
-    SERIAL_PORT = "COM3"
+    SERIAL_PORT = "COM4"  # this is machine-specific
     PUMP = None
 
     # setUp and tearDown will get run between each test method
@@ -108,6 +108,8 @@ class TestPump(unittest.TestCase):
     def test_flowrate(self) -> None:
         current = self.PUMP.flowrate
         self.assertIsInstance(current, float)
+        self.PUMP.flowrate = 9999
+        self.assertEqual(self.PUMP.flowrate, self.PUMP.max_flowrate)
         self.PUMP.flowrate = current
         self.assertEqual(current, self.PUMP.flowrate)
 
@@ -117,6 +119,8 @@ class TestPump(unittest.TestCase):
     def test_upper_pressure_limit(self) -> None:
         current = self.PUMP.upper_pressure_limit
         self.assertIsInstance(current, (float, int))
+        self.PUMP.upper_pressure_limit = 9999
+        self.assertEqual(self.PUMP.upper_pressure_limit, self.PUMP.max_pressure)
         self.PUMP.upper_pressure_limit = current
         self.assertEqual(current, self.PUMP.upper_pressure_limit)
 

--- a/tests/test_pump_base.py
+++ b/tests/test_pump_base.py
@@ -1,0 +1,16 @@
+import sys
+import unittest
+
+
+class TestPumpBase(unittest.TestCase):
+    SERIAL_PORT = "COM3"
+
+    def test_open(self) -> None:
+
+        pass
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        TestPumpBase.SERIAL_PORT = sys.argv.pop()
+    unittest.main()

--- a/tests/test_pump_base.py
+++ b/tests/test_pump_base.py
@@ -1,10 +1,11 @@
-from py_hplc.pump_error import PumpError
 import sys
 import unittest
 
 from serial.serialutil import SerialException
 
 from py_hplc.pump_base import NextGenPumpBase
+from py_hplc.pump_error import PumpError
+
 
 class TestPumpBase(unittest.TestCase):
     SERIAL_PORT = "COM3"
@@ -15,7 +16,7 @@ class TestPumpBase(unittest.TestCase):
         try:
             TestPumpBase.PUMP = NextGenPumpBase(self.SERIAL_PORT)
         except SerialException:
-            self.fail(f'No such port {self.SERIAL_PORT}')
+            self.fail(f"No such port {self.SERIAL_PORT}")
 
     def test_identify(self) -> None:
         """Tests initializing a NextGenPumpBase,
@@ -28,17 +29,17 @@ class TestPumpBase(unittest.TestCase):
         self.assertIsNotNone(pump.version)
         self.assertIsNotNone(pump.head)
         self.assertIsNotNone(pump.flowrate_factor)
-    
+
     def test_write_read(self) -> None:
         pump = TestPumpBase.PUMP
         # redundant assertion that we can read/write
-        self.assertIn('Version', pump.write('id'))
+        self.assertIn("Version", pump.write("id"))
 
     def test_command(self) -> None:
         # make sure bad commands throw an error
         pump = TestPumpBase.PUMP
         self.assertRaises(PumpError, pump.command, "foobar")
-    
+
     def test_close(self) -> None:
         pump = TestPumpBase.PUMP
         pump.close()

--- a/tests/test_pump_base.py
+++ b/tests/test_pump_base.py
@@ -10,15 +10,15 @@ from py_hplc.pump_error import PumpError
 
 
 class TestPumpBase(unittest.TestCase):
-    SERIAL_PORT = "COM3"  # this is machine-specific
+    SERIAL_PORT = "COM4"  # this is machine-specific
     PUMP = None
 
     # setUp and tearDown will get run between each test method
     def setUp(self) -> None:
         try:
             self.PUMP = NextGenPumpBase(self.SERIAL_PORT)
-        except SerialException:
-            self.fail(f"No such port {self.SERIAL_PORT}")
+        except SerialException as err:
+            self.fail(f"No such port {self.SERIAL_PORT} \n {err}")
 
     def tearDown(self) -> None:
         self.PUMP.close()

--- a/tests/test_pump_base.py
+++ b/tests/test_pump_base.py
@@ -1,3 +1,5 @@
+"""This module tests the functionality of the NextGenPumpBase class."""
+
 import sys
 import unittest
 
@@ -8,46 +10,46 @@ from py_hplc.pump_error import PumpError
 
 
 class TestPumpBase(unittest.TestCase):
-    SERIAL_PORT = "COM3"
+    SERIAL_PORT = "COM3"  # this is machine-specific
     PUMP = None
 
+    # setUp and tearDown will get run between each test method
     def setUp(self) -> None:
-        # will both .open() and .identify() on init
         try:
-            TestPumpBase.PUMP = NextGenPumpBase(self.SERIAL_PORT)
+            self.PUMP = NextGenPumpBase(self.SERIAL_PORT)
         except SerialException:
             self.fail(f"No such port {self.SERIAL_PORT}")
+
+    def tearDown(self) -> None:
+        self.PUMP.close()
 
     def test_identify(self) -> None:
         """Tests initializing a NextGenPumpBase,
         as well as its .open and .identify methods.
         """
-        pump = TestPumpBase.PUMP
-        self.assertTrue(pump.is_open)
-        self.assertIsNotNone(pump.max_flowrate)
-        self.assertIsNotNone(pump.max_pressure)
-        self.assertIsNotNone(pump.version)
-        self.assertIsNotNone(pump.head)
-        self.assertIsNotNone(pump.flowrate_factor)
+        self.assertTrue(self.PUMP.is_open)
+        self.assertIsInstance(self.PUMP.max_flowrate, float)
+        self.assertIsInstance(self.PUMP.max_pressure, (float, int))
+        self.assertIsInstance(self.PUMP.version, str)
+        self.assertIsInstance(self.PUMP.head, str)
+        self.assertIsInstance(self.PUMP.flowrate_factor, int)
 
     def test_write_read(self) -> None:
-        pump = TestPumpBase.PUMP
         # redundant assertion that we can read/write
-        self.assertIn("Version", pump.write("id"))
+        self.assertIn("Version", self.PUMP.write("id"))
 
     def test_command(self) -> None:
         # make sure bad commands throw an error
-        pump = TestPumpBase.PUMP
-        self.assertRaises(PumpError, pump.command, "foobar")
+        self.assertRaises(PumpError, self.PUMP.command, "foobar")
 
     def test_close(self) -> None:
-        pump = TestPumpBase.PUMP
-        pump.close()
-        self.assertFalse(pump.is_open)
+        self.PUMP.close()
+        self.assertFalse(self.PUMP.is_open)
 
 
 if __name__ == "__main__":
     # pass in the serial port you want to test on
+    # python -m unittest <FILE> <PORT>
     if len(sys.argv) > 1:
         TestPumpBase.SERIAL_PORT = sys.argv.pop()
     unittest.main()

--- a/tests/test_pump_base.py
+++ b/tests/test_pump_base.py
@@ -1,16 +1,52 @@
+from py_hplc.pump_error import PumpError
 import sys
 import unittest
 
+from serial.serialutil import SerialException
+
+from py_hplc.pump_base import NextGenPumpBase
 
 class TestPumpBase(unittest.TestCase):
     SERIAL_PORT = "COM3"
+    PUMP = None
 
-    def test_open(self) -> None:
+    def setUp(self) -> None:
+        # will both .open() and .identify() on init
+        try:
+            TestPumpBase.PUMP = NextGenPumpBase(self.SERIAL_PORT)
+        except SerialException:
+            self.fail(f'No such port {self.SERIAL_PORT}')
 
-        pass
+    def test_identify(self) -> None:
+        """Tests initializing a NextGenPumpBase,
+        as well as its .open and .identify methods.
+        """
+        pump = TestPumpBase.PUMP
+        self.assertTrue(pump.is_open)
+        self.assertIsNotNone(pump.max_flowrate)
+        self.assertIsNotNone(pump.max_pressure)
+        self.assertIsNotNone(pump.version)
+        self.assertIsNotNone(pump.head)
+        self.assertIsNotNone(pump.flowrate_factor)
+    
+    def test_write_read(self) -> None:
+        pump = TestPumpBase.PUMP
+        # redundant assertion that we can read/write
+        self.assertIn('Version', pump.write('id'))
+
+    def test_command(self) -> None:
+        # make sure bad commands throw an error
+        pump = TestPumpBase.PUMP
+        self.assertRaises(PumpError, pump.command, "foobar")
+    
+    def test_close(self) -> None:
+        pump = TestPumpBase.PUMP
+        pump.close()
+        self.assertFalse(pump.is_open)
 
 
 if __name__ == "__main__":
+    # pass in the serial port you want to test on
     if len(sys.argv) > 1:
         TestPumpBase.SERIAL_PORT = sys.argv.pop()
     unittest.main()


### PR DESCRIPTION
v1.0.0
------
- now has a full test suite! 🎉
- can now initialize a `NextGenPump` instance using either a pre-existing `Serial` instance (new behavior), OR by passing in a string for the port to open a `Serial` instance at (old behavior)
- bundled data retrieval methods such as `current_conditions` or `pump_info` now return custom typed `dataclass`es instead of `dict`s (this is a breaking change)
- fixed an elusive bug that would sometimes cause `NextGenPumpBase`'s `identify` to fail